### PR TITLE
Enable CoW Swap routing on mainnet

### DIFF
--- a/src/swapService/config/mainnet.ts
+++ b/src/swapService/config/mainnet.ts
@@ -44,9 +44,9 @@ const mainnetRoutingConfig: ChainRoutingConfig = [
   ...globalRoutingWrappers,
   // Only fires when the request carries `provider=cow`. Returns a stub swap
   // payload; the frontend builds the CoW order itself against the EVC wrapper.
-  // {
-  //   strategy: StrategyCowSwap.name(),
-  // },
+  {
+    strategy: StrategyCowSwap.name(),
+  },
   // SPECIAL CASE TOKENS
   {
     strategy: StrategyIdleCDOTranche.name(),


### PR DESCRIPTION
## Summary
- Re-enable the provider-gated CoW Swap route on mainnet.
- Restore support for `provider=cow` requests so the frontend can build CoW orders against the EVC wrapper.

## Changes
- Uncomments the `StrategyCowSwap` entry in `mainnetRoutingConfig`.
- Keeps the route in its existing position before the special-case token strategies.

## Test plan
- [x] `git diff --check`
- [ ] `pnpm run lint` (not run: `pnpm` and `corepack` are unavailable on the local shell path)
