### PR TITLE
fix: update CoW Protocol label

### DIFF
--- a/src/swapService/strategies/aggregators/sources/cowQuoteSource.ts
+++ b/src/swapService/strategies/aggregators/sources/cowQuoteSource.ts
@@ -25,7 +25,7 @@ const SUPPORTED_CHAINS: Record<ChainId, string> = {
 }
 
 const COW_METADATA: QuoteSourceMetadata<CoWSupport> = {
-  name: "CoW Swap",
+  name: "CoW Protocol",
   supports: {
     chains: Object.keys(SUPPORTED_CHAINS).map(Number),
     swapAndTransfer: true,
@@ -66,7 +66,7 @@ export class CustomCoWQuoteSource extends AlwaysValidConfigAndContextSource<
   > {
     const origin = (swapParams as QuoteSwapParams).origin
     const receiver = (swapParams as QuoteSwapParams).receiver
-    const appData = `{\"appCode\":\"CoW Swap\",\"environment\":\"production\",\"metadata\":{\"orderClass\":{\"orderClass\":\"market\"},\"quote\":{\"slippageBips\":${Math.floor(slippagePercentage / 100)},\"smartSlippage\":true}},\"version\":\"1.10.0\"}`
+    const appData = `{\"appCode\":\"CoW Protocol\",\"environment\":\"production\",\"metadata\":{\"orderClass\":{\"orderClass\":\"market\"},\"quote\":{\"slippageBips\":${Math.floor(slippagePercentage / 100)},\"smartSlippage\":true}},\"version\":\"1.10.0\"}`
     const appDataHash = keccak256(toHex(appData))
     const queryBody = {
       sellToken,

--- a/src/swapService/strategies/strategyCowSwap.ts
+++ b/src/swapService/strategies/strategyCowSwap.ts
@@ -31,6 +31,7 @@ const COW_CLOSE_POSITION_WRAPPERS: Record<number, Address> = {
 }
 
 export const COW_PROVIDER_NAME = "cow"
+export const COW_PROVIDER_DISPLAY_NAME = "CoW Protocol"
 
 const COW_QUOTE_TIMEOUT_MS = 15_000
 const COW_ORDER_VALID_FOR_SECONDS = 1800
@@ -164,7 +165,7 @@ export class StrategyCowSwap {
           tokenOut: swapParams.tokenOut,
           slippage: swapParams.slippage,
           providerData,
-          route: [{ providerName: "CoW Swap" }],
+          route: [{ providerName: COW_PROVIDER_DISPLAY_NAME }],
           swap,
           verify,
         },


### PR DESCRIPTION
## Summary
- Update CoW quote branding so swap route responses display CoW Protocol instead of CoW Swap.
- Align the custom CoW quote source metadata and appData branding with the route label.

## Changes
- Added a shared CoW provider display-name constant for the direct CoW strategy route output.
- Updated the legacy custom CoW quote source display metadata and appData appCode.

## Test plan
- [x] Ran git diff --check.
- [ ] Automated lint/tests not run locally because dependencies are not installed in this checkout.